### PR TITLE
fix a flaky test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -465,6 +465,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.16.1</version>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <version>${commons.junit.version}</version>

--- a/src/test/java/org/apache/commons/collections4/collection/AbstractCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/AbstractCollectionTest.java
@@ -17,6 +17,7 @@
 package org.apache.commons.collections4.collection;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.*;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -1095,8 +1096,7 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
 
         array = getCollection().toArray(new Object[0]);
         a = getCollection().toArray();
-        assertEquals("toArrays should be equal",
-                     Arrays.asList(array), Arrays.asList(a));
+        assertThat(Arrays.asList(array)).hasSameElementsAs(Arrays.asList(a));
 
         // Figure out if they're all the same class
         // TODO: It'd be nicer to detect a common superclass


### PR DESCRIPTION
### This PR fixed a flaky test
```
org.apache.commons.collections4.bag.TransformedBagTest.testCollectionToArray2
```
### Why it failed:
In `src/test/java/org/apache/commons/collections4/collection/AbstractCollectionTest.java`, `toArray()` in lines 1096 and 1097 does not guarantee the order for the elements, so the non-deterministic order will cause the flaky test with assertion error in line 1098.
### Reproduce test failure:
- Run commands:
```
mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=org.apache.commons.collections4.bag.TransformedBagTest#testCollectionToArray2
```
- Get test failure:
```
[ERROR] org.apache.commons.collections4.bag.TransformedBagTest.testCollectionToArray2
[ERROR]   Run 1: TransformedBagTest>AbstractCollectionTest.testCollectionToArray2:1098 toArrays should be equal expected:<[Three, 16, , 14, Thirteen, 15, 5.0, One, One, Seven, 4, 2, 10, null, Nine, Eight, 11, 6.0, 12]> but was:<[12, 14, 16, Seven, Thirteen, 5.0, 2, 6.0, Nine, One, One, 4, 10, Three, 11, null, 15, Eight, ]>
``` 
### Fix:
Fix the flakiness with assertion without comparing the orders of the elements. Also add the dependency into pom.xml.